### PR TITLE
Update BaseImage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM openjdk:8-jre
 
 ENV PRESTO_VERSION 0.164
 ADD https://repo1.maven.org/maven2/com/facebook/presto/presto-server/${PRESTO_VERSION}/presto-server-${PRESTO_VERSION}.tar.gz presto-server.tar.gz


### PR DESCRIPTION
'java' is deprecated.
Recommended to use 'openjdk' instead.

https://hub.docker.com/_/java/